### PR TITLE
Initial Frontend Improvements

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -11,7 +11,6 @@
 
   
   <title>TSconfig Reference &mdash; TSconfig Reference latest (9-dev) documentation</title>
-  
 
   
   
@@ -555,8 +554,22 @@ address the task at hand.</p>
 	inputSelector: '#searchinput', 
         autocompleteOptions: {
             hint: false,
-	    appendTo: 'section.wy-nav-content-wrap .wy-nav-content'
+	    appendTo: 'ul.sidebartop',
+            templates: {
+                header:
+                    '<div class="algolia-breadcrumbs" role="navigation">' +
+                    '<ul class="al-breadcrumbs">' +
+                    '<li><a href="/Index.html">Docs</a>»</li>' +
+                    '<li>Search</li>' +
+                    '<li class="al-breadcrumbs-aside"> </li>' +
+                    '</ul>' +
+                    '<h2>Search Results</h2></div>'
+            }
 	},
+          algoliaOptions: {
+              hitsPerPage: 10,
+              // See https://www.algolia.com/doc/api-reference/api-parameters/
+          },
 	debug: true // Set debug to true if you want to inspect the dropdown 
       }); 
    </script> 

--- a/_static/css/theme.css
+++ b/_static/css/theme.css
@@ -16,11 +16,13 @@ span.algolia-autocomplete .ds-dropdown-menu {
 }
 
 span.algolia-autocomplete.algolia-autocomplete-left {
-	left: 300px !important;
+	position: initial !important;
+	left: 0 !important;
 	right: 0 !important;
-	width: 1600px !important;
+	width: 100% !important;
 	top: 0 !important;
 	height: 100vh;
+	font-size: 16px;
 }
 
 span.algolia-autocomplete div[class*="ds-dataset"] {
@@ -31,4 +33,65 @@ span.algolia-autocomplete .algolia-docsearch-footer {
 	position: absolute;
 	right: 8px;
 	bottom: 8px;
+}
+
+.algolia-autocomplete h2 {
+	display: none;
+}
+
+.algolia-breadcrumbs {
+	display: none;
+}
+
+.al-breadcrumbs li {
+	display: inline-block;
+}
+
+.al-breadcrumbs li a {
+	display: inline !important;
+	color: #b34700 !important;
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--highlight {
+	color: #333 !important;
+	background: #ffc800 !important;
+}
+
+.algolia-autocomplete .algolia-docsearch-footer {
+	top: 0 !important;
+}
+
+
+@media screen and (min-width: 768px) {
+	span.algolia-autocomplete.algolia-autocomplete-left {
+		position: fixed !important;
+		left: 300px !important;
+		right: 0 !important;
+		width: calc(100% - 300px) !important;
+		top: 0 !important;
+		height: 100vh;
+	}
+
+	.algolia-autocomplete h2 {
+		display: block;
+		color: #333;
+		margin: 0;
+		padding: 10px 2em;
+		background-color: #fcfcfc;
+	}
+
+	.algolia-autocomplete .ds-suggestions {
+		padding: 0 1.8em;
+	}
+
+	.algolia-breadcrumbs {
+		display: block;
+	}
+
+	.algolia-autocomplete .al-breadcrumbs {
+		display: block;
+		padding: 1.618em 2.236em 0;
+		background-color: #fcfcfc;
+		color: #333;
+	}
 }


### PR DESCRIPTION
- Add proper display of search on mobile
- Adjust overlay styling for the desktop view
- Adjust result count to 10
- Adjust styling to resemble current live site a bit

Desktop:
<img width="1435" alt="Screenshot 2019-08-02 at 23 56 35" src="https://user-images.githubusercontent.com/1774242/62400925-500dc880-b581-11e9-8652-2f773a76626e.png">

Mobile:
<img width="373" alt="Screenshot 2019-08-02 at 23 57 14" src="https://user-images.githubusercontent.com/1774242/62400928-569c4000-b581-11e9-804a-b1de6049325d.png">